### PR TITLE
Add DiscordEmbed

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,16 +95,19 @@ $user->notify(new DiscordNotification('test'));
 ### Send embeds
 
 ```php
+use Revolution\Laravel\Notification\DiscordWebhook\DiscordMessage;
+use Revolution\Laravel\Notification\DiscordWebhook\DiscordEmbed;
+
     public function toDiscordWebhook(object $notifiable): DiscordMessage
     {
         return DiscordMessage::create()
-                              ->embeds([
-                                  [
-                                      'title' => 'INFO',
-                                      'description' => $this->content,
-                                      'url' => route('home'),
-                                  ],
-                              ]);
+                              ->embed(
+                                  DiscordEmbed::make(
+                                      title: 'INFO',
+                                      description: $this->content,
+                                      url: route('home'),
+                                  )
+                              );
     }
 ```
 
@@ -131,23 +134,20 @@ use Illuminate\Support\Facades\Storage;
 Using files in embed.
 ```php
 use Revolution\Laravel\Notification\DiscordWebhook\DiscordAttachment;
+use Revolution\Laravel\Notification\DiscordWebhook\DiscordEmbed;
 use Illuminate\Support\Facades\Storage;
 
     public function toDiscordWebhook(object $notifiable): DiscordMessage
     {
         return DiscordMessage::create()
-                              ->embeds([
-                                  [
-                                      'title' => 'test',
-                                      'description' => $this->content,
-                                      'thumbnail' => [
-                                          'url' => 'attachment://test.jpg',
-                                      ],
-                                      'image' => [
-                                          'url' => 'attachment://test2.jpg',
-                                      ],
-                                  ],
-                              ]);
+                              ->embed(
+                                    DiscordEmbed::make(
+                                        title: 'test',
+                                        description: $this->content,
+                                        image: 'attachment://test.jpg',
+                                        thumbnail: 'attachment://test2.jpg',
+                                    )
+                              );
                               ->file(DiscordAttachment::make(
                                    content: Storage::get('test.jpg'),
                                    filename: 'test.jpg', 

--- a/src/DiscordEmbed.php
+++ b/src/DiscordEmbed.php
@@ -1,0 +1,59 @@
+<?php
+
+namespace Revolution\Laravel\Notification\DiscordWebhook;
+
+use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Support\Collection;
+
+final class DiscordEmbed implements Arrayable
+{
+    protected array $options = [];
+
+    public function __construct(
+        protected ?string $title = null,
+        protected ?string $description = null,
+        protected ?string $url = null,
+        protected ?string $image = null,
+        protected ?string $thumbnail = null,
+    )
+    {
+        //
+    }
+
+    public static function make(
+        ?string $title = null,
+        ?string $description = null,
+        ?string $url = null,
+        ?string $image = null,
+        ?string $thumbnail = null,
+    ): self
+    {
+        return new self(...func_get_args());
+    }
+
+    public function with(array $options): self
+    {
+        $this->options = $options;
+
+        return $this;
+    }
+
+    public function toArray(): array
+    {
+        return collect([
+            'title' => $this->title,
+            'description' => $this->description,
+            'url' => $this->url,
+        ])->when(filled($this->image), function (Collection $collection) {
+            $collection->put('image', [
+                'url' => $this->image,
+            ]);
+        })->when(filled($this->thumbnail), function (Collection $collection) {
+            $collection->put('thumbnail', [
+                'url' => $this->thumbnail,
+            ]);
+        })->merge($this->options)
+            ->reject(fn ($item) => blank($item))
+            ->toArray();
+    }
+}

--- a/src/DiscordMessage.php
+++ b/src/DiscordMessage.php
@@ -22,21 +22,30 @@ final class DiscordMessage implements Arrayable, Jsonable
 
     public function __construct(
         protected ?string $content = null,
-        protected ?array $embeds = null,
-    ) {
+        protected array   $embeds = [],
+    )
+    {
         //
     }
 
     public static function create(
         ?string $content = null,
-        ?array $embeds = null,
-    ): self {
+        array   $embeds = [],
+    ): self
+    {
         return new self(...func_get_args());
     }
 
     public function content(string $content): self
     {
         $this->content = $content;
+
+        return $this;
+    }
+
+    public function embed(array|Arrayable $embed): self
+    {
+        $this->embeds[] = $embed instanceof Arrayable ? $embed->toArray() : $embed;
 
         return $this;
     }

--- a/tests/Feature/NotificationTest.php
+++ b/tests/Feature/NotificationTest.php
@@ -14,6 +14,7 @@ use Illuminate\Support\Str;
 use Revolution\Laravel\Notification\DiscordWebhook\DiscordAttachment;
 use Revolution\Laravel\Notification\DiscordWebhook\DiscordChannel;
 use Revolution\Laravel\Notification\DiscordWebhook\DiscordMessage;
+use Revolution\Laravel\Notification\DiscordWebhook\DiscordEmbed;
 use Tests\TestCase;
 
 class NotificationTest extends TestCase
@@ -138,13 +139,39 @@ class NotificationTest extends TestCase
 
         Http::assertSentCount(1);
     }
+
+    public function test_embed()
+    {
+        $embed = DiscordEmbed::make(
+            title: 'title',
+            description: 'description',
+            url: 'url',
+            image: 'image',
+            thumbnail: 'thumbnail'
+        )->with(['color' => 'color']);
+
+        $this->assertSame(['title' => 'title', 'description' => 'description', 'url' => 'url', 'image' => ['url' => 'image'], 'thumbnail' => ['url' => 'thumbnail'], 'color' => 'color'], $embed->toArray());
+    }
+
+    public function test_message_embed()
+    {
+        $embed = DiscordEmbed::make(
+            title: 'title',
+        );
+
+        $m = DiscordMessage::create()
+            ->embed($embed);
+
+        $this->assertSame(['title' => 'title'], $m->toArray()['embeds'][0]);
+    }
 }
 
 class TestNotification extends \Illuminate\Notifications\Notification
 {
     public function __construct(
         protected string $content,
-    ) {
+    )
+    {
     }
 
     public function via(object $notifiable): array
@@ -165,7 +192,8 @@ class TestFileNotification extends \Illuminate\Notifications\Notification
 {
     public function __construct(
         protected string $content,
-    ) {
+    )
+    {
     }
 
     public function via(object $notifiable): array


### PR DESCRIPTION
This PR adds a class to create Embed object.

```php
use Revolution\Laravel\Notification\DiscordWebhook\DiscordMessage;
use Revolution\Laravel\Notification\DiscordWebhook\DiscordEmbed;

    public function toDiscordWebhook(object $notifiable): DiscordMessage
    {
        return DiscordMessage::create()
                              ->embed(
                                  DiscordEmbed::make(
                                      title: 'INFO',
                                      description: $this->content,
                                      url: route('home'),
                                  )
                              );
    }
```